### PR TITLE
Add JENKINS_LOW_SECURITY_DOMAIN feature.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,9 @@ RUN install-plugins.sh \
          workflow-multibranch:2.14 \
          ws-cleanup:0.32
 
+# Designate the default domains to limit strict key checking.
+ENV OUTRIGGER_STRICT_HOST_CHECKING_DISABLED 'github.com bitbucket.org'
+
 # Run the s6-based init.
 ENTRYPOINT ["/init"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ ENV CONFD_OPTS '--backend=env --onetime'
 
 # This contains the repo for docker
 COPY root /
+RUN mkdir -p /root/.ssh
 
 RUN apt-get -y install \
       apt-transport-https \

--- a/README.md
+++ b/README.md
@@ -93,12 +93,27 @@ configurations offered by this image.
 You can pass this as an environment variable to container and it will customize the `admin`
 user password. If this is not set, the `admin` user will have a blank password.
 
-### JENKINS_LOW_SECURITY_DOMAIN
+### OUTRIGGER_STRICT_HOST_CHECKING_DISABLED
 
-Specify a domain, such as `example.com`, which should have a "lower-security" treatment that
-does not require user input when the Jenkins container connects to the domain via SSH.
+Specify a domain for an SSH config file Host entry. This domain will have the SSH
+settig `StrictHostKeyChecking` disabled. As a result, ssh or git commands from
+the Jenkins container will not be challenged for a hosts key entry.
 
-This is intended for use in conjunction with git-based platform-as-a-service providers.
+In keeping with SSH configuration syntax, you can use a single wildcard in your
+host name and may also specify multiple host names delimited by a single space.
+
+As long as you are using key-based authentication this represents a minimal risk
+of exposure to Man-in-the-Middle attacks, for more details see:
+http://www.gremwell.com/ssh-mitm-public-key-authentication
+
+#### Default Value & Example
+
+```
+OUTRIGGER_STRICT_HOST_CHECKING_DISABLED="github.com bitbucket.org"
+```
+
+If you do not wish Github and Bitbucket to have StrictHostKeyChecking disabled,
+set this environment variable to an empty string.
 
 ## Customization
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ configurations offered by this image.
 You can pass this as an environment variable to container and it will customize the `admin`
 user password. If this is not set, the `admin` user will have a blank password.
 
+### JENKINS_LOW_SECURITY_DOMAIN
+
+Specify a domain, such as `example.com`, which should have a "lower-security" treatment that
+does not require user input when the Jenkins container connects to the domain via SSH.
+
+This is intended for use in conjunction with git-based platform-as-a-service providers.
 
 ## Customization
 

--- a/root/etc/confd/conf.d/ssh-config.toml
+++ b/root/etc/confd/conf.d/ssh-config.toml
@@ -1,0 +1,6 @@
+[template]
+src="ssh_config.tmpl"
+dest="/root/.ssh/config"
+keys=[
+  "/",
+]

--- a/root/etc/confd/templates/ssh_config.tmpl
+++ b/root/etc/confd/templates/ssh_config.tmpl
@@ -1,8 +1,4 @@
-Host bitbucket.org
-  StrictHostKeyChecking no
-Host github.com
-  StrictHostKeyChecking no
-{{if getenv "JENKINS_LOW_SECURITY_DOMAIN"}}
-Host {{getenv "JENKINS_LOW_SECURITY_DOMAIN"}}
+{{if getenv "OUTRIGGER_STRICT_HOST_CHECKING_DISABLED"}}
+Host {{getenv "OUTRIGGER_STRICT_HOST_CHECKING_DISABLED"}}
   StrictHostKeyChecking no
 {{end}}

--- a/root/etc/confd/templates/ssh_config.tmpl
+++ b/root/etc/confd/templates/ssh_config.tmpl
@@ -1,0 +1,8 @@
+Host bitbucket.org
+  StrictHostKeyChecking no
+Host github.com
+  StrictHostKeyChecking no
+{{if getenv "JENKINS_LOW_SECURITY_DOMAIN"}}
+Host {{getenv "JENKINS_LOW_SECURITY_DOMAIN"}}
+  StrictHostKeyChecking no
+{{end}}

--- a/root/etc/cont-init.d/20-outrigger-private-key
+++ b/root/etc/cont-init.d/20-outrigger-private-key
@@ -3,10 +3,9 @@
 KEY_BASE=/root/.ssh
 KEY_FILE=$KEY_BASE/outrigger.key
 
-if [ -e $KEY_FILE ]; then
-
+if [ -e $KEY_FILE ] && [ ! -d $KEY_FILE ]
+then
   echo "KEY_FILE found. Setting up key..."
-
 else
 
   echo "##############################################################"
@@ -38,3 +37,6 @@ chmod 600 $PRIVATE_KEY
 # Make sure that commands don't need to prompt for host keys
 ssh-keyscan -H bitbucket.org >> $KEY_BASE/known_hosts
 ssh-keyscan -H github.com >> $KEY_BASE/known_hosts
+if [[ "$JENKINS_LOW_SECURITY_DOMAIN" ]]; then
+  ssh-keyscan -H $JENKINS_LOW_SECURITY_DOMAIN >> $KEY_BASE/known_hosts
+fi

--- a/root/etc/cont-init.d/20-outrigger-private-key
+++ b/root/etc/cont-init.d/20-outrigger-private-key
@@ -33,10 +33,3 @@ fi
 cp $KEY_FILE $PRIVATE_KEY
 chown root:root $PRIVATE_KEY
 chmod 600 $PRIVATE_KEY
-
-# Make sure that commands don't need to prompt for host keys
-ssh-keyscan -H bitbucket.org 2>/dev/null >> $KEY_BASE/known_hosts
-ssh-keyscan -H github.com 2>/dev/null >> $KEY_BASE/known_hosts
-if [[ "$JENKINS_LOW_SECURITY_DOMAIN" ]]; then
-  ssh-keyscan -H $JENKINS_LOW_SECURITY_DOMAIN 2>/dev/null >> $KEY_BASE/known_hosts
-fi

--- a/root/etc/cont-init.d/20-outrigger-private-key
+++ b/root/etc/cont-init.d/20-outrigger-private-key
@@ -35,8 +35,8 @@ chown root:root $PRIVATE_KEY
 chmod 600 $PRIVATE_KEY
 
 # Make sure that commands don't need to prompt for host keys
-ssh-keyscan -H bitbucket.org >> $KEY_BASE/known_hosts
-ssh-keyscan -H github.com >> $KEY_BASE/known_hosts
+ssh-keyscan -H bitbucket.org 2>/dev/null >> $KEY_BASE/known_hosts
+ssh-keyscan -H github.com 2>/dev/null >> $KEY_BASE/known_hosts
 if [[ "$JENKINS_LOW_SECURITY_DOMAIN" ]]; then
-  ssh-keyscan -H $JENKINS_LOW_SECURITY_DOMAIN >> $KEY_BASE/known_hosts
+  ssh-keyscan -H $JENKINS_LOW_SECURITY_DOMAIN 2>/dev/null >> $KEY_BASE/known_hosts
 fi

--- a/root/root/.ssh/config
+++ b/root/root/.ssh/config
@@ -1,4 +1,0 @@
-Host bitbucket.org
-  StrictHostKeyChecking no
-Host github.com
-  StrictHostKeyChecking no


### PR DESCRIPTION
This adds the ability to set an env var with a domain to add to github and bitbucket as "keyscan hosts".

It also has a fix for https://github.com/phase2/docker-build/issues/7, which we need to solve in both repos. Maybe that script should be moved to a utils repo and curl'd on docker build?